### PR TITLE
keibi

### DIFF
--- a/src/fov.c
+++ b/src/fov.c
@@ -53,8 +53,8 @@ void	draw_fov(t_game *game)
 	double	pl[2];
 	int		c[2];
 
-	c[0] = MM_PLAYER_X + MM_RAD * WALL + (WALL - 6) / 4;
-	c[1] = MM_PLAYER_Y + MM_RAD * WALL + (WALL - 6) / 4;
+	c[0] = MM_PLAYER_X + MM_RAD * WALL - (WALL - 6) / 4;
+	c[1] = MM_PLAYER_Y + MM_RAD * WALL - (WALL - 6) / 4;
 	dir[0] = cos(game->player.dire);
 	dir[1] = sin(game->player.dire);
 	pl[0] = -dir[1] * 0.66;

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -20,6 +20,8 @@ int	mouse_move(int x, int y, t_game *game)
 	if (!game->player.mouse_captured)
 		return (0);
 	center_x = WIDTH / 2;
+	if (x == center_x)
+		return (0);
 	game->player.mouse_dx = (float)(x - center_x);
 	mlx_mouse_move(game->mlx, game->win, center_x, HEIGHT / 2);
 	return (0);


### PR DESCRIPTION
rayとplayerの位置がずれていたので修正しました。
足し算と引き算を間違えていました

マウスを使用しているとフリーズする減少があったため、適当な処理を追加しました。
再現性があるバグではないと思っているので、直っているかもしれないし、直っていないかもしれないし、そもそもバグなんてなかったかもしれません。